### PR TITLE
Change killall to pkill

### DIFF
--- a/lcontrol
+++ b/lcontrol
@@ -108,7 +108,7 @@ sub check_used_ports {
 }
 
 sub stop {
-  system("killall socat");
+  system("pkill socat");
 #  my @ps = `/bin/ps ax`;
 #  my $i = 0;
 #  foreach (@ps) {


### PR DESCRIPTION
On some systems, `killall` does precisely that … `pkill` is more portable :-)